### PR TITLE
Change grab methods to be invoked on Listenable and ValueListenable

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,8 +34,8 @@ class _AppState extends State<App> {
           ),
         ),
         floatingActionButton: FloatingActionButton(
-          child: const Icon(Icons.add),
           onPressed: () => _notifier.value++,
+          child: const Icon(Icons.add),
         ),
       ),
     );
@@ -49,7 +49,7 @@ class _Counter extends StatelessWidget with Grab {
   Widget build(BuildContext context) {
     // With context.grab(), the widget is rebuilt every time
     // the value of the notifier is updated.
-    final count = context.grab<int>(_notifier);
+    final count = _notifier.grab(context);
 
     return Text(
       '$count',
@@ -67,7 +67,7 @@ class _SlowCounter extends StatelessWidget with Grab {
     // of the notifier, like 0, 0, 0, 1, 1, 1, 2, 2, 2...
     // Updating the value of the notifier doesn't trigger rebuilds
     // while the result of grabAt() here remains the same.
-    final count = context.grabAt(_notifier, (int v) => v ~/ 3);
+    final count = _notifier.grabAt(context, (v) => v ~/ 3);
 
     return Text(
       '$count',

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -1,10 +1,9 @@
-import 'extensions.dart';
 import 'mixins.dart';
 import 'types.dart';
 
-/// Error thrown when [GrabBuildContext.grab] or [GrabBuildContext.grabAt]
-/// is used without a mixin, either [StatelessGrabMixin] / [Grab] in a
-/// StatelessWidget or [StatefulGrabMixin] / [Grabful] in a StatefulWidget.
+/// Error thrown when `grab()` or `grabAt()` is used without a mixin,
+/// either [StatelessGrabMixin] / [Grab] in a StatelessWidget or
+/// [StatefulGrabMixin] / [Grabful] in a StatefulWidget.
 class GrabMixinError extends Error {
   @override
   String toString() =>

--- a/lib/src/extensions.dart
+++ b/lib/src/extensions.dart
@@ -6,6 +6,13 @@ import 'errors.dart';
 import 'mixins.dart';
 import 'types.dart';
 
+// Note:
+//
+// Changing `GrabListenableExtension on Listenable` to
+// `GrabListenableExtension<R extends Listenable> on R` will cause
+// calls on ValueListenable to invoke the GrabListenableExtension
+// extension instead of GrabValueListenableExtension.
+
 /// Extensions on [Listenable] to provide methods for Grab.
 ///
 /// The widget where the extension methods are used must have an

--- a/lib/src/mixins.dart
+++ b/lib/src/mixins.dart
@@ -3,7 +3,6 @@ import 'package:flutter/widgets.dart';
 
 import 'element.dart';
 import 'errors.dart';
-import 'extensions.dart';
 import 'types.dart';
 
 /// A mixin used on [StatelessWidget] for making Grab available
@@ -27,8 +26,8 @@ import 'types.dart';
 /// {@endtemplate}
 ///
 /// {@template grab.mixin}
-/// The [GrabMixinError] is thrown if either [GrabBuildContext.grab]
-/// or [GrabBuildContext.grabAt] is used without this mixin.
+/// The [GrabMixinError] is thrown if either `grab()` or `grabAt()`
+/// is used without this mixin.
 /// {@endtemplate}
 mixin StatelessGrabMixin on StatelessWidget {
   @override

--- a/test/element_test.dart
+++ b/test/element_test.dart
@@ -25,9 +25,8 @@ void main() {
       await tester.pumpWidget(
         StatelessWithMixin(
           funcCalledInBuild: (context) {
-            context
-              ..grabAt(valueNotifier1, (TestState s) => s.intValue)
-              ..grabAt(valueNotifier2, (TestState s) => s.intValue);
+            valueNotifier1.grabAt(context, (s) => s.intValue);
+            valueNotifier2.grabAt(context, (s) => s.intValue);
           },
         ),
       );
@@ -52,9 +51,8 @@ void main() {
                   children: [
                     StatelessWithMixin(
                       funcCalledInBuild: (context) {
-                        context
-                          ..grabAt(valueNotifier1, (TestState s) => s.intValue)
-                          ..grabAt(valueNotifier2, (TestState s) => s.intValue);
+                        valueNotifier1.grabAt(context, (s) => s.intValue);
+                        valueNotifier2.grabAt(context, (s) => s.intValue);
                       },
                     ),
                     ElevatedButton(

--- a/test/stateful/advanced_test.dart
+++ b/test/stateful/advanced_test.dart
@@ -33,14 +33,11 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              value1 = context.grabAt(
-                changeNotifier,
+              value1 = changeNotifier.grabAt(
+                context,
                 (TestChangeNotifier n) => n.intValue,
               );
-              value2 = context.grabAt(
-                valueNotifier,
-                (TestState s) => s.intValue,
-              );
+              value2 = valueNotifier.grabAt(context, (s) => s.intValue);
               buildCount++;
             },
           ),
@@ -80,26 +77,18 @@ void main() {
               return StatefulWithMixin(
                 funcCalledInBuild: swapped
                     ? (context) {
-                        value2 = context.grabAt(
-                          valueNotifier,
-                          (TestState s) => s.stringValue,
-                        );
-                        value1 = context.grabAt(
-                          valueNotifier,
-                          (TestState s) => s.intValue,
-                        );
+                        value2 =
+                            valueNotifier.grabAt(context, (s) => s.stringValue);
+                        value1 =
+                            valueNotifier.grabAt(context, (s) => s.intValue);
                         isSwapped = true;
                         buildCount++;
                       }
                     : (context) {
-                        value1 = context.grabAt(
-                          valueNotifier,
-                          (TestState s) => s.intValue,
-                        );
-                        value2 = context.grabAt(
-                          valueNotifier,
-                          (TestState s) => s.stringValue,
-                        );
+                        value1 =
+                            valueNotifier.grabAt(context, (s) => s.intValue);
+                        value2 =
+                            valueNotifier.grabAt(context, (s) => s.stringValue);
                         isSwapped = false;
                         buildCount++;
                       },

--- a/test/stateful/error_test.dart
+++ b/test/stateful/error_test.dart
@@ -7,18 +7,26 @@ import '../common/widgets.dart';
 
 void main() {
   group('GrabMixinError', () {
-    late TestChangeNotifier notifier;
+    late TestChangeNotifier changeNotifier;
+    late TestValueNotifier valueNotifier;
 
-    setUp(() => notifier = TestChangeNotifier());
-    tearDown(() => notifier.dispose());
+    setUp(() {
+      changeNotifier = TestChangeNotifier();
+      valueNotifier = TestValueNotifier();
+    });
+    tearDown(() {
+      changeNotifier.dispose();
+      valueNotifier.dispose();
+    });
 
     testWidgets(
-      'Throws if grab() is used in StatefulWidget without mixin',
+      'Throws if grab() is used on Listenable in StatefulWidget '
+      'without mixin',
       (tester) async {
         await tester.pumpWidget(
           StatefulWithoutMixin(
             funcCalledInBuild: (context) {
-              notifier.grab(context);
+              changeNotifier.grab(context);
             },
           ),
         );
@@ -27,12 +35,43 @@ void main() {
     );
 
     testWidgets(
-      'Throws if grabAt() is used in StatefulWidget without mixin',
+      'Throws if grabAt() is used on Listenable in StatefulWidget '
+      'without mixin',
       (tester) async {
         await tester.pumpWidget(
           StatefulWithoutMixin(
             funcCalledInBuild: (context) {
-              notifier.grabAt(context, (_) => null);
+              changeNotifier.grabAt(context, (_) => null);
+            },
+          ),
+        );
+        expect(tester.takeException(), isA<GrabMixinError>());
+      },
+    );
+
+    testWidgets(
+      'Throws if grab() is used on ValueListenable in StatefulWidget '
+      'without mixin',
+      (tester) async {
+        await tester.pumpWidget(
+          StatefulWithoutMixin(
+            funcCalledInBuild: (context) {
+              valueNotifier.grab(context);
+            },
+          ),
+        );
+        expect(tester.takeException(), isA<GrabMixinError>());
+      },
+    );
+
+    testWidgets(
+      'Throws if grabAt() is used on ValueListenable in StatefulWidget '
+      'without mixin',
+      (tester) async {
+        await tester.pumpWidget(
+          StatefulWithoutMixin(
+            funcCalledInBuild: (context) {
+              valueNotifier.grabAt(context, (_) => null);
             },
           ),
         );

--- a/test/stateful/error_test.dart
+++ b/test/stateful/error_test.dart
@@ -18,7 +18,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithoutMixin(
             funcCalledInBuild: (context) {
-              context.grab<TestChangeNotifier>(notifier);
+              notifier.grab(context);
             },
           ),
         );
@@ -32,7 +32,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithoutMixin(
             funcCalledInBuild: (context) {
-              context.grabAt(notifier, (_) => null);
+              notifier.grabAt(context, (_) => null);
             },
           ),
         );

--- a/test/stateful/grab_at_test.dart
+++ b/test/stateful/grab_at_test.dart
@@ -27,10 +27,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              context.grabAt(
-                changeNotifier,
-                (TestChangeNotifier n) => selectorValue = n,
-              );
+              changeNotifier.grabAt(context, (n) => selectorValue = n);
             },
           ),
         );
@@ -47,10 +44,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              context.grabAt(
-                valueNotifier,
-                (TestState s) => selectorValue = s,
-              );
+              valueNotifier.grabAt(context, (s) => selectorValue = s);
             },
           ),
         );
@@ -67,10 +61,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              value = context.grabAt(
-                valueNotifier,
-                (TestState s) => s.intValue,
-              );
+              value = valueNotifier.grabAt(context, (s) => s.intValue);
             },
           ),
         );
@@ -87,10 +78,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              value = context.grabAt(
-                valueNotifier,
-                (TestState s) => s.intValue,
-              );
+              value = valueNotifier.grabAt(context, (s) => s.intValue);
             },
           ),
         );
@@ -115,8 +103,8 @@ void main() {
             children: [
               StatefulWithMixin(
                 funcCalledInBuild: (context) {
-                  value1 = context.grabAt(
-                    changeNotifier,
+                  value1 = changeNotifier.grabAt(
+                    context,
                     (TestChangeNotifier n) => n.intValue,
                   );
                   buildCount1++;
@@ -124,8 +112,8 @@ void main() {
               ),
               StatefulWithMixin(
                 funcCalledInBuild: (context) {
-                  value2 = context.grabAt(
-                    changeNotifier,
+                  value2 = changeNotifier.grabAt(
+                    context,
                     (TestChangeNotifier n) => n.stringValue,
                   );
                   buildCount2++;
@@ -172,19 +160,13 @@ void main() {
             children: [
               StatefulWithMixin(
                 funcCalledInBuild: (context) {
-                  value1 = context.grabAt(
-                    valueNotifier,
-                    (TestState s) => s.intValue,
-                  );
+                  value1 = valueNotifier.grabAt(context, (s) => s.intValue);
                   buildCount1++;
                 },
               ),
               StatefulWithMixin(
                 funcCalledInBuild: (context) {
-                  value2 = context.grabAt(
-                    valueNotifier,
-                    (TestState s) => s.stringValue,
-                  );
+                  value2 = valueNotifier.grabAt(context, (s) => s.stringValue);
                   buildCount2++;
                 },
               ),
@@ -229,8 +211,8 @@ void main() {
             children: [
               StatefulWithMixin(
                 funcCalledInBuild: (context) {
-                  final notifier = context.grabAt(
-                    changeNotifier,
+                  final notifier = changeNotifier.grabAt(
+                    context,
                     (TestChangeNotifier n) => n,
                   );
                   value1 = notifier.intValue;
@@ -239,8 +221,8 @@ void main() {
               ),
               StatefulWithMixin(
                 funcCalledInBuild: (context) {
-                  final notifier = context.grabAt(
-                    changeNotifier,
+                  final notifier = changeNotifier.grabAt(
+                    context,
                     (TestChangeNotifier n) => n,
                   );
                   value2 = notifier.stringValue;
@@ -282,9 +264,9 @@ void main() {
                 children: [
                   StatefulWithMixin(
                     funcCalledInBuild: (context) {
-                      value = context.grabAt(
-                        valueNotifier,
-                        (TestState s) => s.intValue * multiplier,
+                      value = valueNotifier.grabAt(
+                        context,
+                        (s) => s.intValue * multiplier,
                       );
                     },
                   ),

--- a/test/stateful/grab_test.dart
+++ b/test/stateful/grab_test.dart
@@ -26,7 +26,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              value = context.grab(changeNotifier);
+              value = changeNotifier.grab(context);
             },
           ),
         );
@@ -41,7 +41,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              value = context.grab(valueNotifier);
+              value = valueNotifier.grab(context);
             },
           ),
         );
@@ -58,7 +58,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              context.grab<TestChangeNotifier>(changeNotifier);
+              changeNotifier.grab(context);
               intValue = changeNotifier.intValue;
               stringValue = changeNotifier.stringValue;
             },
@@ -87,7 +87,7 @@ void main() {
         await tester.pumpWidget(
           StatefulWithMixin(
             funcCalledInBuild: (context) {
-              state = context.grab(valueNotifier);
+              state = valueNotifier.grab(context);
             },
           ),
         );

--- a/test/stateless/advanced_test.dart
+++ b/test/stateless/advanced_test.dart
@@ -33,14 +33,11 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              value1 = context.grabAt(
-                changeNotifier,
+              value1 = changeNotifier.grabAt(
+                context,
                 (TestChangeNotifier n) => n.intValue,
               );
-              value2 = context.grabAt(
-                valueNotifier,
-                (TestState s) => s.intValue,
-              );
+              value2 = valueNotifier.grabAt(context, (s) => s.intValue);
               buildCount++;
             },
           ),
@@ -80,26 +77,18 @@ void main() {
               return StatelessWithMixin(
                 funcCalledInBuild: swapped
                     ? (context) {
-                        value2 = context.grabAt(
-                          valueNotifier,
-                          (TestState s) => s.stringValue,
-                        );
-                        value1 = context.grabAt(
-                          valueNotifier,
-                          (TestState s) => s.intValue,
-                        );
+                        value2 =
+                            valueNotifier.grabAt(context, (s) => s.stringValue);
+                        value1 =
+                            valueNotifier.grabAt(context, (s) => s.intValue);
                         isSwapped = true;
                         buildCount++;
                       }
                     : (context) {
-                        value1 = context.grabAt(
-                          valueNotifier,
-                          (TestState s) => s.intValue,
-                        );
-                        value2 = context.grabAt(
-                          valueNotifier,
-                          (TestState s) => s.stringValue,
-                        );
+                        value1 =
+                            valueNotifier.grabAt(context, (s) => s.intValue);
+                        value2 =
+                            valueNotifier.grabAt(context, (s) => s.stringValue);
                         isSwapped = false;
                         buildCount++;
                       },

--- a/test/stateless/error_test.dart
+++ b/test/stateless/error_test.dart
@@ -7,18 +7,26 @@ import '../common/widgets.dart';
 
 void main() {
   group('GrabMixinError', () {
-    late TestChangeNotifier notifier;
+    late TestChangeNotifier changeNotifier;
+    late TestValueNotifier valueNotifier;
 
-    setUp(() => notifier = TestChangeNotifier());
-    tearDown(() => notifier.dispose());
+    setUp(() {
+      changeNotifier = TestChangeNotifier();
+      valueNotifier = TestValueNotifier();
+    });
+    tearDown(() {
+      changeNotifier.dispose();
+      valueNotifier.dispose();
+    });
 
     testWidgets(
-      'Throws if grab() is used in StatelessWidget without mixin',
+      'Throws if grab() is used on Listenable in StatelessWidget '
+      'without mixin',
       (tester) async {
         await tester.pumpWidget(
           StatelessWithoutMixin(
             funcCalledInBuild: (context) {
-              notifier.grab(context);
+              changeNotifier.grab(context);
             },
           ),
         );
@@ -27,12 +35,43 @@ void main() {
     );
 
     testWidgets(
-      'Throws if grabAt() is used in StatelessWidget without mixin',
+      'Throws if grabAt() is used on Listenable in StatelessWidget '
+      'without mixin',
       (tester) async {
         await tester.pumpWidget(
           StatelessWithoutMixin(
             funcCalledInBuild: (context) {
-              notifier.grabAt(context, (_) => null);
+              changeNotifier.grabAt(context, (_) => null);
+            },
+          ),
+        );
+        expect(tester.takeException(), isA<GrabMixinError>());
+      },
+    );
+
+    testWidgets(
+      'Throws if grab() is used on ValueListenable in StatelessWidget '
+      'without mixin',
+      (tester) async {
+        await tester.pumpWidget(
+          StatelessWithoutMixin(
+            funcCalledInBuild: (context) {
+              valueNotifier.grab(context);
+            },
+          ),
+        );
+        expect(tester.takeException(), isA<GrabMixinError>());
+      },
+    );
+
+    testWidgets(
+      'Throws if grabAt() is used on ValueListenable in StatelessWidget '
+      'without mixin',
+      (tester) async {
+        await tester.pumpWidget(
+          StatelessWithoutMixin(
+            funcCalledInBuild: (context) {
+              valueNotifier.grabAt(context, (_) => null);
             },
           ),
         );

--- a/test/stateless/error_test.dart
+++ b/test/stateless/error_test.dart
@@ -18,7 +18,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithoutMixin(
             funcCalledInBuild: (context) {
-              context.grab<TestChangeNotifier>(notifier);
+              notifier.grab(context);
             },
           ),
         );
@@ -32,7 +32,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithoutMixin(
             funcCalledInBuild: (context) {
-              context.grabAt(notifier, (_) => null);
+              notifier.grabAt(context, (_) => null);
             },
           ),
         );

--- a/test/stateless/grab_at_test.dart
+++ b/test/stateless/grab_at_test.dart
@@ -27,10 +27,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              context.grabAt(
-                changeNotifier,
-                (TestChangeNotifier n) => selectorValue = n,
-              );
+              changeNotifier.grabAt(context, (n) => selectorValue = n);
             },
           ),
         );
@@ -47,10 +44,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              context.grabAt(
-                valueNotifier,
-                (TestState s) => selectorValue = s,
-              );
+              valueNotifier.grabAt(context, (s) => selectorValue = s);
             },
           ),
         );
@@ -67,10 +61,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              value = context.grabAt(
-                valueNotifier,
-                (TestState s) => s.intValue,
-              );
+              value = valueNotifier.grabAt(context, (s) => s.intValue);
             },
           ),
         );
@@ -87,10 +78,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              value = context.grabAt(
-                valueNotifier,
-                (TestState s) => s.intValue,
-              );
+              value = valueNotifier.grabAt(context, (s) => s.intValue);
             },
           ),
         );
@@ -115,8 +103,8 @@ void main() {
             children: [
               StatelessWithMixin(
                 funcCalledInBuild: (context) {
-                  value1 = context.grabAt(
-                    changeNotifier,
+                  value1 = changeNotifier.grabAt(
+                    context,
                     (TestChangeNotifier n) => n.intValue,
                   );
                   buildCount1++;
@@ -124,8 +112,8 @@ void main() {
               ),
               StatelessWithMixin(
                 funcCalledInBuild: (context) {
-                  value2 = context.grabAt(
-                    changeNotifier,
+                  value2 = changeNotifier.grabAt(
+                    context,
                     (TestChangeNotifier n) => n.stringValue,
                   );
                   buildCount2++;
@@ -172,19 +160,13 @@ void main() {
             children: [
               StatelessWithMixin(
                 funcCalledInBuild: (context) {
-                  value1 = context.grabAt(
-                    valueNotifier,
-                    (TestState s) => s.intValue,
-                  );
+                  value1 = valueNotifier.grabAt(context, (s) => s.intValue);
                   buildCount1++;
                 },
               ),
               StatelessWithMixin(
                 funcCalledInBuild: (context) {
-                  value2 = context.grabAt(
-                    valueNotifier,
-                    (TestState s) => s.stringValue,
-                  );
+                  value2 = valueNotifier.grabAt(context, (s) => s.stringValue);
                   buildCount2++;
                 },
               ),
@@ -229,8 +211,8 @@ void main() {
             children: [
               StatelessWithMixin(
                 funcCalledInBuild: (context) {
-                  final notifier = context.grabAt(
-                    changeNotifier,
+                  final notifier = changeNotifier.grabAt(
+                    context,
                     (TestChangeNotifier n) => n,
                   );
                   value1 = notifier.intValue;
@@ -239,8 +221,8 @@ void main() {
               ),
               StatelessWithMixin(
                 funcCalledInBuild: (context) {
-                  final notifier = context.grabAt(
-                    changeNotifier,
+                  final notifier = changeNotifier.grabAt(
+                    context,
                     (TestChangeNotifier n) => n,
                   );
                   value2 = notifier.stringValue;
@@ -282,9 +264,9 @@ void main() {
                 children: [
                   StatelessWithMixin(
                     funcCalledInBuild: (context) {
-                      value = context.grabAt(
-                        valueNotifier,
-                        (TestState s) => s.intValue * multiplier,
+                      value = valueNotifier.grabAt(
+                        context,
+                        (s) => s.intValue * multiplier,
                       );
                     },
                   ),

--- a/test/stateless/grab_test.dart
+++ b/test/stateless/grab_test.dart
@@ -26,7 +26,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              value = context.grab(changeNotifier);
+              value = changeNotifier.grab(context);
             },
           ),
         );
@@ -41,7 +41,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              value = context.grab(valueNotifier);
+              value = valueNotifier.grab(context);
             },
           ),
         );
@@ -58,7 +58,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              context.grab<TestChangeNotifier>(changeNotifier);
+              changeNotifier.grab(context);
               intValue = changeNotifier.intValue;
               stringValue = changeNotifier.stringValue;
             },
@@ -87,7 +87,7 @@ void main() {
         await tester.pumpWidget(
           StatelessWithMixin(
             funcCalledInBuild: (context) {
-              state = context.grab(valueNotifier);
+              state = valueNotifier.grab(context);
             },
           ),
         );


### PR DESCRIPTION
Closes #1.

This PR removes the `BuildContext` extension and adds new ones with methods with the same name but called on `Listenable` and `ValueListenable` instead of BuildContext.
