### PR TITLE
Increase GC cycles to make tests less flaky

### DIFF
--- a/test/common/utils.dart
+++ b/test/common/utils.dart
@@ -2,13 +2,11 @@ import 'dart:developer' show reachabilityBarrier;
 
 import 'package:flutter_test/flutter_test.dart';
 
-const _kFullGcCycles = 2;
-
 // Simplified version of https://github.com/dart-lang/leak_tracker/blob/db1e95b4c34fd572e2f3c7e8eb1ca099fab681e8/pkgs/leak_tracker/lib/src/leak_tracking/helpers.dart#L25-L48.
 //
 // This does not seem to work in widget tests.
-Future<void> forceGC() async {
-  final barrier = reachabilityBarrier + _kFullGcCycles;
+Future<void> forceGC({int fullGcCycles = 3}) async {
+  final barrier = reachabilityBarrier + fullGcCycles;
   final storage = <List<int>>[];
 
   void allocateMemory() {


### PR DESCRIPTION
Fixes #8

The failing tests pass if the number of GC cycles is changed from 2 to 3 in my environment, but a new test, which is going to be added soon for another issue, still fails if it is 3 and passes with 4. So I have changed `forceGC()` so that a preferred value can be passed in depending on the necessity per test.