### PR TITLE
Fix memory leak caused if selector of `grabAt()` captures variable from outer scope

### DIFF
--- a/lib/src/grab.dart
+++ b/lib/src/grab.dart
@@ -46,6 +46,7 @@ final class Grab extends StatefulWidget {
 
 class _GrabState extends State<Grab> {
   late final GrabManager _manager;
+  bool _isDisposed = false;
 
   @visibleForTesting
   // ignore: diagnostic_describe_all_properties
@@ -65,12 +66,15 @@ class _GrabState extends State<Grab> {
     // before a new build.
     owner?.onBuildScheduled = () {
       originalOnBuildScheduled?.call();
-      _manager.onBeforeBuild();
+      if (!_isDisposed) {
+        _manager.onBeforeBuild();
+      }
     };
   }
 
   @override
   void dispose() {
+    _isDisposed = true;
     Grab._state = null;
     _manager.dispose();
     super.dispose();

--- a/test/common/widgets.dart
+++ b/test/common/widgets.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 
 class TestStatelessWidget extends StatelessWidget {
   const TestStatelessWidget({required this.funcCalledInBuild, this.child});
@@ -28,4 +28,11 @@ class _TestStatefulWidgetState extends State<TestStatefulWidget> {
     widget.funcCalledInBuild(context);
     return const SizedBox.shrink();
   }
+}
+
+class UnmountableBuildContext extends StatelessElement {
+  UnmountableBuildContext() : super(const Text(''));
+
+  @override
+  bool mounted = true;
 }


### PR DESCRIPTION
Fixes #7

As the title says, the leak occurs if a selector is using a variable from outside the closure. It causes the BuildContext, with which `grabAt()` is called, to keep being referenced even after it becomes unmounted and therefore be excluded from garbage collection.

This fix adds code to remove the selectors that are associated with already unmounted BuildContexts to make those ready to be GCed. The removal requires an iteration of a map to find unnecessary BuildContexts, which can be a bit costly, so in order to have as little impact on performance as possible, it is not executed aggressively but only while the app is idling.

This PR also contains an improvement to prevent `onBeforeBuild()` from being called after Grab is disposed. Without it, the method is called again after disposal, where the timer to remove selectors restarts. It is not very harmful itself on an app, but it causes tests to fail with the error of "A Timer is still pending even after the widget tree was disposed."